### PR TITLE
Non-ARC compatibility, Interface Builder designables compatibility, scientific notation no longer borks parsing

### DIFF
--- a/BezierCurve4.svg
+++ b/BezierCurve4.svg
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg width="300px" height="195px" viewBox="0 0 300 195" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:sketch="http://www.bohemiancoding.com/sketch/ns">
+    <!-- Generator: Sketch 3.2.2 (9983) - http://www.bohemiancoding.com/sketch -->
+    <title>BezierCurve4</title>
+    <desc>Created with Sketch.</desc>
+    <defs></defs>
+    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" sketch:type="MSPage">
+        <path d="M0,67 C0,67 34,1.92835465e-08 60,-2.22044605e-16 C86,-1.92835472e-08 90,116 120,116 C150,116 156,67.0000033 180,67.0000017 C204,67 221,116 240,116 C259,116 300,67 300,67 L300,195 L0,195 L0,67 Z" id="BezierCurve4" stroke="#000000" stroke-width="3" sketch:type="MSShapeGroup"></path>
+    </g>
+</svg>


### PR DESCRIPTION
- added non-ARC compatibility

- used -[NSBundle bundleForClass:] instead of -[NSBundle mainBundle] so that SVG files can be found when running inside Interface Builder

- fixed parsing of numbers represented in scientific notation (e.g.. 1.234e-8). I also added and SVG file that contains coords in scientific notation.