### PR TITLE
Support Quadratic Bézier paths

### DIFF
--- a/PocketSVG.h
+++ b/PocketSVG.h
@@ -40,12 +40,20 @@
 #endif
 	CGPoint			lastPoint;
 	CGPoint			lastControlPoint;
-	BOOL			validLastControlPoint;
 	NSCharacterSet  *separatorSet;
 	NSCharacterSet  *commandSet;
     
     NSMutableArray  *tokens;
 }
+
+typedef NS_ENUM(NSInteger, PocketSVGControlPoint) {
+    PocketSVGControlPointInvalid,
+    PocketSVGControlPointS,
+    PocketSVGControlPointQ
+};
+
+@property(nonatomic) PocketSVGControlPoint controlPointType;
+
 #if TARGET_OS_IPHONE
 @property(nonatomic, readonly) UIBezierPath *bezier;
 #else

--- a/PocketSVG.m
+++ b/PocketSVG.m
@@ -95,7 +95,8 @@ unichar const invalidCommand		= '*';
     if (acutalValance == targetValence) {
         return YES;
     }
-    NSLog(@"*** PocketSVG Error: %ld parameters for %hu command, expected %ld", (long)acutalValance, self.command, (long)targetValence);
+    unichar const invalidCommand = self.command;
+    NSLog(@"*** PocketSVG Error: %ld parameters for %@ command, expected %ld", (long)acutalValance, [NSString stringWithCharacters:&invalidCommand length:1], (long)targetValence);
     return NO;
 }
 
@@ -459,7 +460,7 @@ unichar const invalidCommand		= '*';
                 x = lastPoint.x;
                 y = lastPoint.y;
             case 'L':
-                if (![token doesValenceMatch:1]) {
+                if (![token doesValenceMatch:2]) {
                     return;
                 }
                 x += [token parameter:index++];


### PR DESCRIPTION
Adds support for:
- Quadratic Bézier (Q,q)
- Smooth quadratic Bézier (T,t)

SVG 1.1: [Quadratic Bezier Commands](http://www.w3.org/TR/SVG/paths.html#PathDataQuadraticBezierCommand)

*Note:* NSBezierPath doesn't support adding quadratic curves. The approximation using the cubic bezier function should be very accurate unless the path is scaled extremely large.