### PR TITLE
cross-platform improvements

### DIFF
--- a/PocketSVG.xcodeproj/project.pbxproj
+++ b/PocketSVG.xcodeproj/project.pbxproj
@@ -25,8 +25,6 @@
 		C798011C1A21CEC200380860 /* libxml2.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = C798011B1A21CEC200380860 /* libxml2.dylib */; };
 		C79801281A21F13E00380860 /* SVGImageView.h in Headers */ = {isa = PBXBuildFile; fileRef = C79801271A21F13E00380860 /* SVGImageView.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		C79801291A21F13E00380860 /* SVGImageView.h in Headers */ = {isa = PBXBuildFile; fileRef = C79801271A21F13E00380860 /* SVGImageView.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		C798012E1A21F35C00380860 /* SVGImageView_iOS.h in Headers */ = {isa = PBXBuildFile; fileRef = C798012B1A21F35C00380860 /* SVGImageView_iOS.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		C79801311A21F35C00380860 /* SVGImageView_Mac.h in Headers */ = {isa = PBXBuildFile; fileRef = C798012C1A21F35C00380860 /* SVGImageView_Mac.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		C79801321A21F35C00380860 /* SVGImageView.m in Sources */ = {isa = PBXBuildFile; fileRef = C798012D1A21F35C00380860 /* SVGImageView.m */; };
 		C79801331A21F35C00380860 /* SVGImageView.m in Sources */ = {isa = PBXBuildFile; fileRef = C798012D1A21F35C00380860 /* SVGImageView.m */; };
 /* End PBXBuildFile section */
@@ -45,8 +43,6 @@
 		C79800F51A21CDFD00380860 /* PocketSVG.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = PocketSVG.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		C798011B1A21CEC200380860 /* libxml2.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libxml2.dylib; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.10.sdk/usr/lib/libxml2.dylib; sourceTree = DEVELOPER_DIR; };
 		C79801271A21F13E00380860 /* SVGImageView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SVGImageView.h; sourceTree = SOURCE_ROOT; };
-		C798012B1A21F35C00380860 /* SVGImageView_iOS.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SVGImageView_iOS.h; sourceTree = SOURCE_ROOT; };
-		C798012C1A21F35C00380860 /* SVGImageView_Mac.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SVGImageView_Mac.h; sourceTree = SOURCE_ROOT; };
 		C798012D1A21F35C00380860 /* SVGImageView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SVGImageView.m; sourceTree = SOURCE_ROOT; };
 /* End PBXFileReference section */
 
@@ -79,8 +75,6 @@
 				C79800D91A21CB9A00380860 /* SVGLayer.h */,
 				C79800DA1A21CB9A00380860 /* SVGLayer.m */,
 				C79801271A21F13E00380860 /* SVGImageView.h */,
-				C798012B1A21F35C00380860 /* SVGImageView_iOS.h */,
-				C798012C1A21F35C00380860 /* SVGImageView_Mac.h */,
 				C798012D1A21F35C00380860 /* SVGImageView.m */,
 				1DC5ADD11CC9B17A008FDA98 /* SVGBezierPath.h */,
 				1DC5ADD21CC9B17A008FDA98 /* SVGBezierPath.mm */,
@@ -117,7 +111,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				C79800E01A21CB9A00380860 /* SVGLayer.h in Headers */,
-				C798012E1A21F35C00380860 /* SVGImageView_iOS.h in Headers */,
 				C79801281A21F13E00380860 /* SVGImageView.h in Headers */,
 				C79800E21A21CB9A00380860 /* PocketSVG.h in Headers */,
 				1DC5ADD31CC9B17A008FDA98 /* SVGBezierPath.h in Headers */,
@@ -130,7 +123,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				C79801151A21CEAE00380860 /* SVGLayer.h in Headers */,
-				C79801311A21F35C00380860 /* SVGImageView_Mac.h in Headers */,
 				1DC5ADD41CC9B17A008FDA98 /* SVGBezierPath.h in Headers */,
 				C79801171A21CEB000380860 /* SVGPortability.h in Headers */,
 				C79801291A21F13E00380860 /* SVGImageView.h in Headers */,

--- a/SVGBezierPath.h
+++ b/SVGBezierPath.h
@@ -1,7 +1,7 @@
 #import "SVGPortability.h"
 
 NS_ASSUME_NONNULL_BEGIN
-@interface SVGBezierPath : SVGUI(BezierPath)
+@interface SVGBezierPath : BezierPath
 @property(nonatomic, readonly) NSDictionary<NSString*, id> *svgAttributes;
 @property(nonatomic, readonly) NSString *SVGRepresentation;
 #if !TARGET_OS_IPHONE

--- a/SVGBezierPath.h
+++ b/SVGBezierPath.h
@@ -1,7 +1,7 @@
 #import "SVGPortability.h"
 
 NS_ASSUME_NONNULL_BEGIN
-@interface SVGBezierPath : BezierPath
+@interface SVGBezierPath : PSVGBezierPath
 @property(nonatomic, readonly) NSDictionary<NSString*, id> *svgAttributes;
 @property(nonatomic, readonly) NSString *SVGRepresentation;
 #if !TARGET_OS_IPHONE

--- a/SVGImageView.h
+++ b/SVGImageView.h
@@ -1,14 +1,10 @@
-#import <TargetConditionals.h>
+#import "SVGPortability.h"
 
-// This setup is just so Interface Builder doesn't get confused.
-#if TARGET_OS_IPHONE
-#   import "SVGImageView_iOS.h"
-#else
-#   import "SVGImageView_Mac.h"
-#endif
-
-@interface SVGImageView ()
+IB_DESIGNABLE
+@interface SVGImageView : View
 @property(nonatomic, copy) IBInspectable NSString *svgName;
 @property(nonatomic) IBInspectable BOOL scaleLineWidth;
+@property(nonatomic, copy) NSString *svgSource;
+@property(nonatomic, copy) IBInspectable Color *fillColor, *strokeColor;
 + (instancetype)imageViewWithSVGNamed:(NSString *)aSVGName;
 @end

--- a/SVGImageView.h
+++ b/SVGImageView.h
@@ -1,10 +1,10 @@
 #import "SVGPortability.h"
 
 IB_DESIGNABLE
-@interface SVGImageView : View
+@interface SVGImageView : PSVGView
 @property(nonatomic, copy) IBInspectable NSString *svgName;
 @property(nonatomic) IBInspectable BOOL scaleLineWidth;
 @property(nonatomic, copy) NSString *svgSource;
-@property(nonatomic, copy) IBInspectable Color *fillColor, *strokeColor;
+@property(nonatomic, copy) IBInspectable PSVGColor *fillColor, *strokeColor;
 + (instancetype)imageViewWithSVGNamed:(NSString *)aSVGName;
 @end

--- a/SVGImageView.m
+++ b/SVGImageView.m
@@ -49,11 +49,11 @@
     _svgName = aName;
     [self._svgLayer loadSVGNamed:_svgName];
 }
-- (void)setFillColor:(SVGUI(Color) * const)aColor {
+- (void)setFillColor:(Color * const)aColor {
     _fillColor = aColor;
     self._svgLayer.fillColor = aColor.CGColor;
 }
-- (void)setStrokeColor:(SVGUI(Color) * const)aColor {
+- (void)setStrokeColor:(Color * const)aColor {
     _strokeColor = aColor;
     self._svgLayer.strokeColor = aColor.CGColor;
 }

--- a/SVGImageView.m
+++ b/SVGImageView.m
@@ -49,11 +49,11 @@
     _svgName = aName;
     [self._svgLayer loadSVGNamed:_svgName];
 }
-- (void)setFillColor:(Color * const)aColor {
+- (void)setFillColor:(PSVGColor * const)aColor {
     _fillColor = aColor;
     self._svgLayer.fillColor = aColor.CGColor;
 }
-- (void)setStrokeColor:(Color * const)aColor {
+- (void)setStrokeColor:(PSVGColor * const)aColor {
     _strokeColor = aColor;
     self._svgLayer.strokeColor = aColor.CGColor;
 }

--- a/SVGImageView_Mac.h
+++ b/SVGImageView_Mac.h
@@ -1,7 +1,0 @@
-#import <AppKit/AppKit.h>
-
-IB_DESIGNABLE
-@interface SVGImageView : NSView
-@property(nonatomic, copy) NSString *svgSource;
-@property(nonatomic, copy) IBInspectable NSColor *fillColor, *strokeColor;
-@end

--- a/SVGImageView_iOS.h
+++ b/SVGImageView_iOS.h
@@ -1,7 +1,0 @@
-#import <UIKit/UIKit.h>
-
-IB_DESIGNABLE
-@interface SVGImageView : UIView
-@property(nonatomic, copy) NSString *svgSource;
-@property(nonatomic, copy) IBInspectable UIColor *fillColor, *strokeColor;
-@end

--- a/SVGLayer.m
+++ b/SVGLayer.m
@@ -206,7 +206,7 @@ CGRect _AdjustCGRectForContentsGravity(CGRect aRect, CGSize aSize, NSString *aGr
         
         layer.fillColor   = _fillColor
                          ?: (__bridge CGColorRef)path.svgAttributes[@"fill"]
-                         ?: [[Color blackColor] CGColor];
+                         ?: [[PSVGColor blackColor] CGColor];
         layer.strokeColor = _strokeColor
                          ?: (__bridge CGColorRef)path.svgAttributes[@"stroke"];
         if (_scaleLineWidth && path.svgAttributes[@"stroke-width"]) {

--- a/SVGLayer.m
+++ b/SVGLayer.m
@@ -206,7 +206,7 @@ CGRect _AdjustCGRectForContentsGravity(CGRect aRect, CGSize aSize, NSString *aGr
         
         layer.fillColor   = _fillColor
                          ?: (__bridge CGColorRef)path.svgAttributes[@"fill"]
-                         ?: [[SVGUI(Color) blackColor] CGColor];
+                         ?: [[Color blackColor] CGColor];
         layer.strokeColor = _strokeColor
                          ?: (__bridge CGColorRef)path.svgAttributes[@"stroke"];
         if (_scaleLineWidth && path.svgAttributes[@"stroke-width"]) {

--- a/SVGPortability.h
+++ b/SVGPortability.h
@@ -1,13 +1,17 @@
 #import <TargetConditionals.h>
 
 #if TARGET_OS_IPHONE
-#   import <UIKit/UIKit.h>
-#   define View UIView
-#   define Color UIColor
-#   define BezierPath UIBezierPath
+
+#import <UIKit/UIKit.h>
+@compatibility_alias PSVGView UIView;
+@compatibility_alias PSVGColor UIColor;
+@compatibility_alias PSVGBezierPath UIBezierPath;
+
 #else
-#   import <AppKit/AppKit.h>
-#   define View NSView
-#   define Color NSColor
-#   define BezierPath NSBezierPath
+
+#import <AppKit/AppKit.h>
+@compatibility_alias PSVGView NSView;
+@compatibility_alias PSVGColor NSColor;
+@compatibility_alias PSVGBezierPath NSBezierPath;
+
 #endif

--- a/SVGPortability.h
+++ b/SVGPortability.h
@@ -2,8 +2,12 @@
 
 #if TARGET_OS_IPHONE
 #   import <UIKit/UIKit.h>
-#   define SVGUI(kls) UI##kls
+#   define View UIView
+#   define Color UIColor
+#   define BezierPath UIBezierPath
 #else
 #   import <AppKit/AppKit.h>
-#   define SVGUI(kls) NS##kls
+#   define View NSView
+#   define Color NSColor
+#   define BezierPath NSBezierPath
 #endif


### PR DESCRIPTION
* `SVGImageView_iOS.h`, `SVGImageView_Mac.h` and `SVGImageView.h` are doing what should be the job of just one file, so i merged them into `SVGImageView.h`
* The `SVGUI(kls) UI##kls` is clever, but is really not very readable. I changed it to a more verbose list of `#defines` (inspired by [Nuke](https://github.com/kean/Nuke/blob/master/Sources/Nuke.swift), as it'll be easier for users to understand what they are. 