### PR TITLE
Skip all characters in whitespace character set (rather than just space characters) when parsing paths

### DIFF
--- a/PocketSVG.m
+++ b/PocketSVG.m
@@ -314,7 +314,7 @@ unichar const invalidCommand        = '*';
     while (index < [attr length]) {
         unichar charAtIndex = [attr characterAtIndex:index];
         //Jagie:Skip whitespace
-        if (charAtIndex == 32) {
+        if ([[NSCharacterSet whitespaceCharacterSet] characterIsMember:charAtIndex]) {
             index ++;
             continue;
         }


### PR DESCRIPTION
Not considering tab (U+0009) as whitespace was causing parsing errors in valid SVG files.