### PR TITLE
Fix 'SVGEngine.h' file not found error in v2 branch

### DIFF
--- a/PocketSVG.podspec
+++ b/PocketSVG.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   s.frameworks  = 'QuartzCore'
   s.library   = 'xml2'
   s.xcconfig = { 'HEADER_SEARCH_PATHS' => '$(SDKROOT)/usr/include/libxml2' }
-  s.source_files = 'PocketSVG.{h,mm}', 'SVGBezierPath.{h,mm}', 'SVGImageView.{h,m}', 'SVGLayer.{h,m}', 'SVGPortability.h' 
+  s.source_files = 'PocketSVG.{h,mm}', 'SVGBezierPath.{h,mm}', 'SVGEngine.{h,mm}', 'SVGImageView.{h,m}', 'SVGLayer.{h,m}', 'SVGPortability.h' 
  s.ios.source_files = 'SVGImageView_iOS.h'
  s.osx.source_files = 'SVGImageView_Mac.h'
 end


### PR DESCRIPTION
Because `'SVGEngine.h' file not found` error occurred during build, I've added them to podspec.